### PR TITLE
Replaced compiler-specific integer suffix

### DIFF
--- a/Anime4KCore/include/Anime4K.h
+++ b/Anime4KCore/include/Anime4K.h
@@ -83,7 +83,7 @@ public:
     void loadVideo(const std::string& srcFile);
     void loadImage(const std::string& srcFile);
     void loadImage(const cv::InputArray srcImage);
-    void loadImage(int rows, int cols, unsigned char* data, size_t bytesPerLine = 0Ui64);
+    void loadImage(int rows, int cols, unsigned char* data, size_t bytesPerLine = 0ULL);
     void loadImage(int rows, int cols, unsigned char* r, unsigned char* g, unsigned char* b);
     void setVideoSaveInfo(const std::string& dstFile,const CODEC codec = MP4V);
     void saveImage(const std::string& dstFile);


### PR DESCRIPTION
The latest commit didn't compile with clang-10 for me. Changing the integer suffix to a C++ standard one fixed it.